### PR TITLE
Minor, uncontroversial changes

### DIFF
--- a/bookcontents/chapter-01/chapter-01.md
+++ b/bookcontents/chapter-01/chapter-01.md
@@ -225,7 +225,7 @@ import org.lwjgl.system.MemoryUtil;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private GLFWKeyCallbackI keyCallback;
@@ -289,7 +289,7 @@ if (!GLFWVulkan.glfwVulkanSupported()) {
 The code above, will test if the minimal requirements to use Vulkan are available (the Vulkan loader and a minimal functional ICD). This does not imply that Vulkan will work properly, but it is a minimum. Without this there is no sense in going on. The rest of the methods are basic ones to free resources, handling window resizing, etc.
 
 ```java
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
     ...
     public void cleanup() {
         glfwFreeCallbacks(windowHandle);
@@ -311,11 +311,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
     
     public boolean isKeyPressed(int keyCode) {

--- a/bookcontents/chapter-02/chapter-02.md
+++ b/bookcontents/chapter-02/chapter-02.md
@@ -126,9 +126,9 @@ public class Instance {
     ...
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+		IntBuffer numLayersArr = stack.callocInt(1);
+		vkEnumerateInstanceLayerProperties(numLayersArr, null);
+		int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
         ...
     }

--- a/bookcontents/chapter-02/chapter-02.md
+++ b/bookcontents/chapter-02/chapter-02.md
@@ -434,6 +434,7 @@ public class Instance {
 Finally, we can use the Instance class in our `Render` class, in the constructor and `cleanup` methods.
 ```java
 public class Render {
+	private final Instance instance;
     ...
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/bookcontents/chapter-03/chapter-03.md
+++ b/bookcontents/chapter-03/chapter-03.md
@@ -131,12 +131,13 @@ Let's now review the definition of the instance attributes and methods of the `P
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+    
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
     ...
 }
 ```
@@ -162,26 +163,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
     ...
@@ -310,8 +311,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+    
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 ```
 
 The Vulkan structure `VkDevice` is the one that will hold or Vulkan logical device. We will use that structure for the creation of the resources we will need later on. We will hold also a reference to the `PhysicalDevice` instance (which will be passed in the constructor) for convenience (some calls will require later on both the logical and the physical devices). It is turn now for the constructor, which starts like this:
@@ -480,8 +482,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+    
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");
@@ -529,7 +532,7 @@ public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private VkQueue vkQueue;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");
@@ -605,11 +608,11 @@ Now that we have finished our `PhysicalDevice`, `Device`, `Surface` and `Queue` 
 ```java
 public class Render {
     ...
-    private Device device;
-    private Queue.GraphicsQueue graphQueue;
+    private final Device device;
+    private final Queue.GraphicsQueue graphQueue;
     ...
-    private PhysicalDevice physicalDevice;
-    private Surface surface;
+    private final PhysicalDevice physicalDevice;
+    private final Surface surface;
     ...
 }
 ```

--- a/bookcontents/chapter-04/chapter-04.md
+++ b/bookcontents/chapter-04/chapter-04.md
@@ -30,10 +30,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private long vkSwapChain;
+    
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");
@@ -313,7 +314,10 @@ Now we iterate over the images to create new `ImageView` instances. The `ImageVi
 ```java
 ...
 public class ImageView {
-    ...
+	
+    private final Device device;
+    private final long vkImageView;
+
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -383,7 +387,7 @@ Now we can use the `Swapchain` class in our `Render`class:
 public class Render {
     ...
     private SwapChain swapChain;
-    ...
+
     public Render(Window window, Scene scene) {
         ...
         swapChain = new SwapChain(device, surface, window, engProps.getRequestedImages(),

--- a/bookcontents/chapter-05/chapter-05.md
+++ b/bookcontents/chapter-05/chapter-05.md
@@ -22,6 +22,8 @@ We will encapsulate render pass creation which will use as an output  the `SwapC
 
 ```java
 public class SwapChainRenderPass {
+	
+	private final Swapchain swapchain;
     ...
     public SwapChainRenderPass(SwapChain swapChain) {
         this.swapChain = swapChain;
@@ -85,6 +87,8 @@ Now we can create the render pass and finish the constructor:
 ```java
 public class SwapChainRenderPass {
     ...
+    private final long vkRenderPass;
+    
     public SwapChainRenderPass(SwapChain swapChain) {
         ...
             VkRenderPassCreateInfo renderPassInfo = VkRenderPassCreateInfo.callocStack(stack) renderPassInfo = VkRenderPassCreateInfo renderPassInfo = VkRenderPassCreateInfo.callocStack(stack).calloc()
@@ -136,8 +140,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+    
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;
@@ -189,9 +194,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+    
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+    
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");
@@ -236,12 +243,18 @@ Now that are able to create command pools, let's review the class that will allo
 
 ```java
 public class CommandBuffer {
-    ...
+	
+    private static final Logger LOGGER = LogManager.getLogger();
+    
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
+    
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)
@@ -345,8 +358,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;
@@ -388,8 +401,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;
@@ -439,11 +452,11 @@ The first step is optional, depending on your case you can pre-record your comma
 ```java
 public class Render {
     ...
-    private CommandPool commandPool;
+    private final CommandPool commandPool;
     ...
-    private Queue.PresentQueue presentQueue;
+    private final Queue.PresentQueue presentQueue;
     ..
-    private ForwardRenderActivity fwdRenderActivity;
+    private final ForwardRenderActivity fwdRenderActivity;
     ...
 
     public Render(Window window, Scene scene) {
@@ -524,9 +537,10 @@ As you can see it matches the render loop figure presented above. The `SwapChain
 ```java
 public class SwapChain {
     ...
-    private int currentFrame;
-    private SyncSemaphores[] syncSemaphoresList;
+    private final SyncSemaphores[] syncSemaphoresList;
     ...
+
+    private int currentFrame;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         ...
@@ -829,7 +843,9 @@ public class SwapChainRenderPass {
     ...
 }
 public SwapChainRenderPass(SwapChain swapChain) {
-    this.swapChain = swapChain;
+
+	private final SwapChain swapChain;
+	private final long vkRenderPass;
 
     try (MemoryStack stack = MemoryStack.stackPush()) {
     ...

--- a/bookcontents/chapter-06/chapter-06.md
+++ b/bookcontents/chapter-06/chapter-06.md
@@ -203,8 +203,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
 
     private static final int NUMBER_OF_ATTRIBUTES = 1;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+    
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);
@@ -574,8 +575,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {
@@ -744,9 +745,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+    
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+    
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/bookcontents/chapter-07/chapter-07.md
+++ b/bookcontents/chapter-07/chapter-07.md
@@ -178,9 +178,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+    
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/bookcontents/chapter-08/chapter-08.md
+++ b/bookcontents/chapter-08/chapter-08.md
@@ -522,7 +522,7 @@ Now that the `Texture` class is complete, we are ready to to use it. In 3D model
 ```java
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();
@@ -770,8 +770,10 @@ import static org.lwjgl.vulkan.VK11.vkDestroyDescriptorSetLayout;
 public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    
     protected long vkDescriptorLayout;
-    private Device device;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;
@@ -851,8 +853,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+    
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/bookcontents/chapter-10/chapter-10.md
+++ b/bookcontents/chapter-10/chapter-10.md
@@ -36,10 +36,11 @@ public class GeometryAttachments {
 
     public static final int NUMBER_ATTACHMENTS = 2;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+    
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;
@@ -93,8 +94,9 @@ The next step is to define the render pass used to render the geometry. We will 
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+    
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;
@@ -252,9 +254,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+    
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");
@@ -761,8 +764,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();
@@ -837,9 +841,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+    
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+    
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");
@@ -1047,9 +1054,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/bookcontents/chapter-12/chapter-12.md
+++ b/bookcontents/chapter-12/chapter-12.md
@@ -54,7 +54,7 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class MemoryAllocator {
 
-    private long vmaAllocator;
+    private final long vmaAllocator;
 
     public MemoryAllocator(Instance instance, PhysicalDevice physicalDevice, VkDevice vkDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -126,12 +126,13 @@ The next step is to modify the `VulkanBuffer` class to use the VMA library. We w
 ```java
 public class VulkanBuffer {
 
-    private long allocation;
-    private long buffer;
-    private Device device;
+    private final long allocation;
+    private final long buffer;
+    private final Device device;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+    
     private long mappedMemory;
-    private PointerBuffer pb;
-    private long requestedSize;
     ...
 }
 ```

--- a/bookcontents/chapter-13/chapter-13.md
+++ b/bookcontents/chapter-13/chapter-13.md
@@ -238,8 +238,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class ShadowsRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+    
+    private final Device device;
+    private final long vkRenderPass;
 
     public ShadowsRenderPass(Device device, Attachment depthAttachment) {
         this.device = device;

--- a/bookcontents/chapter-14/chapter-14.md
+++ b/bookcontents/chapter-14/chapter-14.md
@@ -562,10 +562,12 @@ In order to support the execution of commands that will go through the compute p
 ```java
 public class ComputePipeline {
 
+    
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+    
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public ComputePipeline(PipelineCache pipelineCache, ComputePipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         ...
@@ -766,7 +768,7 @@ import static org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
 
 public class MemoryBarrier {
 
-    private VkMemoryBarrier.Buffer vkMemoryBarrier;
+    private final VkMemoryBarrier.Buffer vkMemoryBarrier;
 
     public MemoryBarrier(int srcAccessMask, int dstAccessMask) {
         vkMemoryBarrier = VkMemoryBarrier.calloc(1)

--- a/booksamples/chapter-01/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-01/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -6,7 +6,7 @@ import org.vulkanb.eng.scene.Scene;
 
 public class Render {
 
-    private Instance instance;
+    private final Instance instance;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-02/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -6,11 +6,11 @@ import org.vulkanb.eng.scene.Scene;
 
 public class Render {
 
-    private Device device;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private Surface surface;
+    private final Device device;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final Surface surface;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -11,7 +11,7 @@ public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private VkQueue vkQueue;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-03/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -6,11 +6,12 @@ import org.vulkanb.eng.scene.Scene;
 
 public class Render {
 
-    private Device device;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private Surface surface;
+    private final Device device;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final Surface surface;
+
     private SwapChain swapChain;
 
     public Render(Window window, Scene scene) {

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -11,7 +11,7 @@ public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private VkQueue vkQueue;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-04/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,10 +14,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private long vkSwapChain;
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
@@ -11,11 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class ForwardRenderActivity {
 
-    private CommandBuffer[] commandBuffers;
-    private Fence[] fences;
-    private FrameBuffer[] frameBuffers;
-    private SwapChainRenderPass renderPass;
-    private SwapChain swapChain;
+    private final CommandBuffer[] commandBuffers;
+    private final Fence[] fences;
+    private final FrameBuffer[] frameBuffers;
+    private final SwapChainRenderPass renderPass;
+    private final SwapChain swapChain;
 
     public ForwardRenderActivity(SwapChain swapChain, CommandPool commandPool) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-05/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
@@ -18,13 +18,14 @@ public class ForwardRenderActivity {
     private static final String FRAGMENT_SHADER_FILE_SPV = FRAGMENT_SHADER_FILE_GLSL + ".spv";
     private static final String VERTEX_SHADER_FILE_GLSL = "resources/shaders/fwd_vertex.glsl";
     private static final String VERTEX_SHADER_FILE_SPV = VERTEX_SHADER_FILE_GLSL + ".spv";
-    private CommandBuffer[] commandBuffers;
-    private Fence[] fences;
-    private FrameBuffer[] frameBuffers;
-    private ShaderProgram fwdShaderProgram;
-    private Pipeline pipeLine;
-    private SwapChainRenderPass renderPass;
-    private SwapChain swapChain;
+
+    private final CommandBuffer[] commandBuffers;
+    private final Fence[] fences;
+    private final FrameBuffer[] frameBuffers;
+    private final ShaderProgram fwdShaderProgram;
+    private final Pipeline pipeLine;
+    private final SwapChainRenderPass renderPass;
+    private final SwapChain swapChain;
 
     public ForwardRenderActivity(SwapChain swapChain, CommandPool commandPool, PipelineCache pipelineCache) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -12,17 +12,17 @@ public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private CommandPool commandPool;
-    private Device device;
-    private ForwardRenderActivity fwdRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
-    private SwapChain swapChain;
-    private List<VulkanModel> vulkanModels;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final ForwardRenderActivity fwdRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final SwapChain swapChain;
+    private final List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -8,8 +8,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
 
     private static final int NUMBER_OF_ATTRIBUTES = 1;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-06/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -11,8 +11,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanMesh> vulkanMeshList;
+    private final String modelId;
+    private final List<VulkanMesh> vulkanMeshList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
@@ -20,16 +20,18 @@ public class ForwardRenderActivity {
     private static final String FRAGMENT_SHADER_FILE_SPV = FRAGMENT_SHADER_FILE_GLSL + ".spv";
     private static final String VERTEX_SHADER_FILE_GLSL = "resources/shaders/fwd_vertex.glsl";
     private static final String VERTEX_SHADER_FILE_SPV = VERTEX_SHADER_FILE_GLSL + ".spv";
-    private CommandBuffer[] commandBuffers;
-    private Attachment[] depthAttachments;
-    private Device device;
-    private Fence[] fences;
+
+    private final CommandBuffer[] commandBuffers;
+    private final Device device;
+    private final Fence[] fences;
+    private final ShaderProgram fwdShaderProgram;
+    private final Pipeline pipeLine;
+    private final PipelineCache pipelineCache;
+    private final SwapChainRenderPass renderPass;
+    private final Scene scene;
+
     private FrameBuffer[] frameBuffers;
-    private ShaderProgram fwdShaderProgram;
-    private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
-    private SwapChainRenderPass renderPass;
-    private Scene scene;
+    private Attachment[] depthAttachments;
     private SwapChain swapChain;
 
     public ForwardRenderActivity(SwapChain swapChain, CommandPool commandPool, PipelineCache pipelineCache, Scene scene) {

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -12,17 +12,18 @@ public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private CommandPool commandPool;
-    private Device device;
-    private ForwardRenderActivity fwdRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final ForwardRenderActivity fwdRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -9,8 +9,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     public static final int TEXT_COORD_COMPONENTS = 2;
     private static final int NUMBER_OF_ATTRIBUTES = 2;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final Device device;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-07/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -11,8 +11,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMesh> vulkanMeshList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMesh> vulkanMeshList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
@@ -19,21 +19,23 @@ public class ForwardRenderActivity {
     private static final String FRAGMENT_SHADER_FILE_SPV = FRAGMENT_SHADER_FILE_GLSL + ".spv";
     private static final String VERTEX_SHADER_FILE_GLSL = "resources/shaders/fwd_vertex.glsl";
     private static final String VERTEX_SHADER_FILE_SPV = VERTEX_SHADER_FILE_GLSL + ".spv";
-    private CommandBuffer[] commandBuffers;
+
+    private final Device device;
+    private final CommandBuffer[] commandBuffers;
+    private final Fence[] fences;
+    private final ShaderProgram fwdShaderProgram;
+    private final Pipeline pipeLine;
+    private final PipelineCache pipelineCache;
+    private final SwapChainRenderPass renderPass;
+    private final Scene scene;
+
     private Attachment[] depthAttachments;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
-    private Fence[] fences;
     private FrameBuffer[] frameBuffers;
-    private ShaderProgram fwdShaderProgram;
-    private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private SwapChainRenderPass renderPass;
-    private Scene scene;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;
     private TextureSampler textureSampler;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -12,18 +12,19 @@ public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private CommandPool commandPool;
-    private Device device;
-    private ForwardRenderActivity fwdRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final ForwardRenderActivity fwdRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -12,8 +12,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+
     protected long vkDescriptorLayout;
-    private Device device;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,9 +13,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,17 +11,19 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -9,8 +9,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     public static final int TEXT_COORD_COMPONENTS = 2;
     private static final int NUMBER_OF_ATTRIBUTES = 2;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final Device device;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-08/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/ForwardRenderActivity.java
@@ -19,25 +19,27 @@ public class ForwardRenderActivity {
     private static final String FRAGMENT_SHADER_FILE_SPV = FRAGMENT_SHADER_FILE_GLSL + ".spv";
     private static final String VERTEX_SHADER_FILE_GLSL = "resources/shaders/fwd_vertex.glsl";
     private static final String VERTEX_SHADER_FILE_SPV = VERTEX_SHADER_FILE_GLSL + ".spv";
-    private CommandBuffer[] commandBuffers;
+
+    private final Device device;
+    private final CommandBuffer[] commandBuffers;
+    private final Fence[] fences;
+    private final ShaderProgram fwdShaderProgram;
+    private final int materialSize;
+    private final Pipeline pipeLine;
+    private final PipelineCache pipelineCache;
+    private final SwapChainRenderPass renderPass;
+    private final Scene scene;
+
     private Attachment[] depthAttachments;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
-    private Fence[] fences;
     private FrameBuffer[] frameBuffers;
-    private ShaderProgram fwdShaderProgram;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
-    private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private SwapChainRenderPass renderPass;
-    private Scene scene;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;
     private TextureSampler textureSampler;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -12,18 +12,19 @@ public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private CommandPool commandPool;
-    private Device device;
-    private ForwardRenderActivity fwdRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final ForwardRenderActivity fwdRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,9 +13,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -9,8 +9,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     public static final int TEXT_COORD_COMPONENTS = 2;
     private static final int NUMBER_OF_ATTRIBUTES = 2;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final Device device;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-09/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -13,19 +13,21 @@ import java.util.*;
 public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 2;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -20,22 +20,23 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -19,16 +19,17 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final PipelineCache pipelineCache;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
-    private LightingFrameBuffer lightingFrameBuffer;
     private Pipeline pipeline;
-    private PipelineCache pipelineCache;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
 

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,9 +13,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -9,8 +9,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     public static final int TEXT_COORD_COMPONENTS = 2;
     private static final int NUMBER_OF_ATTRIBUTES = 2;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final Device device;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-10/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -13,19 +13,21 @@ import java.util.*;
 public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 4;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -20,22 +20,23 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -21,22 +21,23 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Vector4f auxVec;
+    private final Device device;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
-    private Vector4f auxVec;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
     private VulkanBuffer invProjBuffer;
     private DescriptorSet.UniformDescriptorSet invProjMatrixDescriptorSet;
-    private LightingFrameBuffer lightingFrameBuffer;
     private VulkanBuffer[] lightsBuffers;
     private DescriptorSet.UniformDescriptorSet[] lightsDescriptorSets;
     private Pipeline pipeline;
-    private PipelineCache pipelineCache;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,9 +13,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -29,26 +30,26 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -13,13 +13,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -10,8 +10,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     private static final int NORMAL_COMPONENTS = 3;
     private static final int NUMBER_OF_ATTRIBUTES = 5;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -12,13 +12,14 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocationSize;
-    private long buffer;
-    private Device device;
+    private final long allocationSize;
+    private final long buffer;
+    private final Device device;
+    private final long memory;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private long memory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int usage, int reqMask) {
         this.device = device;

--- a/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-11/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -13,19 +13,21 @@ import java.util.*;
 public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private Surface surface;
+
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 4;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -20,22 +20,23 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
@@ -8,10 +8,9 @@ import java.nio.ByteBuffer;
 
 public class LightSpecConstants {
 
-    private ByteBuffer data;
-
-    private VkSpecializationMapEntry.Buffer specEntryMap;
-    private VkSpecializationInfo specInfo;
+    private final ByteBuffer data;
+    private final VkSpecializationMapEntry.Buffer specEntryMap;
+    private final VkSpecializationInfo specInfo;
 
     public LightSpecConstants() {
         data = MemoryUtil.memAlloc(GraphConstants.INT_LENGTH);

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -21,23 +21,24 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Vector4f auxVec;
+    private final LightSpecConstants lightSpecConstants;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
-    private Vector4f auxVec;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
     private VulkanBuffer invProjBuffer;
     private DescriptorSet.UniformDescriptorSet invProjMatrixDescriptorSet;
-    private LightSpecConstants lightSpecConstants;
-    private LightingFrameBuffer lightingFrameBuffer;
     private VulkanBuffer[] lightsBuffers;
     private DescriptorSet.UniformDescriptorSet[] lightsDescriptorSets;
     private Pipeline pipeline;
-    private PipelineCache pipelineCache;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
+    private final Image image;
+    private final ImageView imageView;
+
     private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
 
     public Attachment(Device device, int width, int height, int format, int usage) {
         image = new Image(device, width, height, format, usage | VK_IMAGE_USAGE_SAMPLED_BIT, 1, 1);

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,10 +13,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private MemoryAllocator memoryAllocator;
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final MemoryAllocator memoryAllocator;
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(Instance instance, PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private Device device;
-    private long vkImageView;
+    private final Device device;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
@@ -10,7 +10,7 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class MemoryAllocator {
 
-    private long vmaAllocator;
+    private final long vmaAllocator;
 
     public MemoryAllocator(Instance instance, PhysicalDevice physicalDevice, VkDevice vkDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -15,12 +15,12 @@ public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private Set<Integer> suportedSampleCount;
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -30,28 +30,28 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             suportedSampleCount = calSupportedSampleCount(vkPhysicalDeviceProperties);
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -13,13 +13,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -10,8 +10,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     private static final int NORMAL_COMPONENTS = 3;
     private static final int NUMBER_OF_ATTRIBUTES = 5;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocation;
-    private long buffer;
-    private Device device;
+    private final long allocation;
+    private final long buffer;
+    private final Device device;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int bufferUsage, int memoryUsage,
                         int requiredFlags) {

--- a/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-12/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -14,20 +14,22 @@ import java.util.*;
 public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private ShadowRenderActivity shadowRenderActivity;
-    private Surface surface;
+
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final ShadowRenderActivity shadowRenderActivity;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 4;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -20,22 +20,23 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
@@ -9,10 +9,9 @@ import java.nio.ByteBuffer;
 
 public class LightSpecConstants {
 
-    private ByteBuffer data;
-
-    private VkSpecializationMapEntry.Buffer specEntryMap;
-    private VkSpecializationInfo specInfo;
+    private final ByteBuffer data;
+    private final VkSpecializationMapEntry.Buffer specEntryMap;
+    private final VkSpecializationInfo specInfo;
 
     public LightSpecConstants() {
         EngineProperties engineProperties = EngineProperties.getInstance();

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -22,23 +22,24 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Vector4f auxVec;
+    private final LightSpecConstants lightSpecConstants;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
-    private Vector4f auxVec;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
     private VulkanBuffer[] invMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] invMatricesDescriptorSets;
-    private LightSpecConstants lightSpecConstants;
-    private LightingFrameBuffer lightingFrameBuffer;
     private VulkanBuffer[] lightsBuffers;
     private DescriptorSet.UniformDescriptorSet[] lightsDescriptorSets;
     private Pipeline pipeline;
-    private PipelineCache pipelineCache;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private VulkanBuffer[] shadowsMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] shadowsMatricesDescriptorSets;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
@@ -21,15 +21,16 @@ public class ShadowRenderActivity {
     private static final String SHADOW_VERTEX_SHADER_FILE_GLSL = "resources/shaders/shadow_vertex.glsl";
     private static final String SHADOW_VERTEX_SHADER_FILE_SPV = SHADOW_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Scene scene;
+    private final ShadowsFrameBuffer shadowsFrameBuffer;
+
     private List<CascadeShadow> cascadeShadows;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Pipeline pipeLine;
     private DescriptorSet.UniformDescriptorSet[] projMatrixDescriptorSet;
-    private Scene scene;
     private ShaderProgram shaderProgram;
-    private ShadowsFrameBuffer shadowsFrameBuffer;
     private VulkanBuffer[] shadowsUniforms;
     private SwapChain swapChain;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
@@ -13,9 +13,9 @@ public class ShadowsFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Attachment depthAttachment;
-    private FrameBuffer frameBuffer;
-    private ShadowsRenderPass shadowsRenderPass;
+    private final Attachment depthAttachment;
+    private final FrameBuffer frameBuffer;
+    private final ShadowsRenderPass shadowsRenderPass;
 
     public ShadowsFrameBuffer(Device device) {
         LOGGER.debug("Creating ShadowsFrameBuffer");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
@@ -12,8 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class ShadowsRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public ShadowsRenderPass(Device device, Attachment depthAttachment) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,9 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
-    private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
+    private final Image image;
+    private final ImageView imageView;
+    private final boolean depthAttachment;
 
     public Attachment(Image image, ImageView imageView, boolean depthAttachment) {
         this.image = image;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,10 +13,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private MemoryAllocator memoryAllocator;
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final MemoryAllocator memoryAllocator;
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(Instance instance, PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass, int layers) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this(device, width, height, format, usage, mipLevels, sampleCount, 1);

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,10 +10,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private int aspectMask;
-    private Device device;
-    private int mipLevels;
-    private long vkImageView;
+    private final int aspectMask;
+    private final Device device;
+    private final int mipLevels;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this(device, vkImage, format, aspectMask, mipLevels, VK_IMAGE_VIEW_TYPE_2D, 0, 1);

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
@@ -10,7 +10,7 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class MemoryAllocator {
 
-    private long vmaAllocator;
+    private final long vmaAllocator;
 
     public MemoryAllocator(Instance instance, PhysicalDevice physicalDevice, VkDevice vkDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -15,12 +15,12 @@ public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private Set<Integer> suportedSampleCount;
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -30,28 +30,28 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             suportedSampleCount = calSupportedSampleCount(vkPhysicalDeviceProperties);
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -10,8 +10,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     private static final int NORMAL_COMPONENTS = 3;
     private static final int NUMBER_OF_ATTRIBUTES = 5;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocation;
-    private long buffer;
-    private Device device;
+    private final long allocation;
+    private final long buffer;
+    private final Device device;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int bufferUsage, int memoryUsage,
                         int requiredFlags) {

--- a/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-13/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,8 +13,8 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -15,21 +15,23 @@ import java.util.*;
 public class Render {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private AnimationComputeActivity animationComputeActivity;
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private ShadowRenderActivity shadowRenderActivity;
-    private Surface surface;
+
+    private final AnimationComputeActivity animationComputeActivity;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final ShadowRenderActivity shadowRenderActivity;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/animation/AnimationComputeActivity.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/animation/AnimationComputeActivity.java
@@ -19,19 +19,20 @@ public class AnimationComputeActivity {
     private static final String ANIM_COMPUTE_SHADER_FILE_SPV = ANIM_COMPUTE_SHADER_FILE_GLSL + ".spv";
     private static final int LOCAL_SIZE_X = 32;
 
-    private MemoryBarrier memoryBarrier;
+    private final Device device;
+    private final MemoryBarrier memoryBarrier;
+    private final Queue.ComputeQueue computeQueue;
+    // Key is the entity id
+    private final Map<String, List<EntityAnimationBuffer>> entityAnimationsBuffers;
+    // Key is the model id
+    private final Map<String, ModelDescriptorSets> modelDescriptorSetsMap;
+    private final Scene scene;
+
     private CommandBuffer commandBuffer;
     private ComputePipeline computePipeline;
-    private Queue.ComputeQueue computeQueue;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
-    // Key is the entity id
-    private Map<String, List<EntityAnimationBuffer>> entityAnimationsBuffers;
     private Fence fence;
-    // Key is the model id
-    private Map<String, ModelDescriptorSets> modelDescriptorSetsMap;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private DescriptorSetLayout.StorageDescriptorSetLayout storageDescriptorSetLayout;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 4;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -21,23 +21,24 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
 
-    private MemoryBarrier memoryBarrier;
+    private final Device device;
+    private final MemoryBarrier memoryBarrier;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final int binding;
+    private final Device device;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
@@ -9,10 +9,9 @@ import java.nio.ByteBuffer;
 
 public class LightSpecConstants {
 
-    private ByteBuffer data;
-
-    private VkSpecializationMapEntry.Buffer specEntryMap;
-    private VkSpecializationInfo specInfo;
+    private final ByteBuffer data;
+    private final VkSpecializationMapEntry.Buffer specEntryMap;
+    private final VkSpecializationInfo specInfo;
 
     public LightSpecConstants() {
         EngineProperties engineProperties = EngineProperties.getInstance();

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -22,23 +22,24 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Vector4f auxVec;
+    private final LightSpecConstants lightSpecConstants;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
-    private Vector4f auxVec;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
     private VulkanBuffer[] invMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] invMatricesDescriptorSets;
-    private LightSpecConstants lightSpecConstants;
-    private LightingFrameBuffer lightingFrameBuffer;
     private VulkanBuffer[] lightsBuffers;
     private DescriptorSet.UniformDescriptorSet[] lightsDescriptorSets;
     private Pipeline pipeline;
-    private PipelineCache pipelineCache;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private VulkanBuffer[] shadowsMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] shadowsMatricesDescriptorSets;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
@@ -22,15 +22,16 @@ public class ShadowRenderActivity {
     private static final String SHADOW_VERTEX_SHADER_FILE_GLSL = "resources/shaders/shadow_vertex.glsl";
     private static final String SHADOW_VERTEX_SHADER_FILE_SPV = SHADOW_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Scene scene;
+    private final ShadowsFrameBuffer shadowsFrameBuffer;
+
     private List<CascadeShadow> cascadeShadows;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Pipeline pipeLine;
     private DescriptorSet.UniformDescriptorSet[] projMatrixDescriptorSet;
-    private Scene scene;
     private ShaderProgram shaderProgram;
-    private ShadowsFrameBuffer shadowsFrameBuffer;
     private VulkanBuffer[] shadowsUniforms;
     private SwapChain swapChain;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
@@ -13,9 +13,9 @@ public class ShadowsFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Attachment depthAttachment;
-    private FrameBuffer frameBuffer;
-    private ShadowsRenderPass shadowsRenderPass;
+    private final Attachment depthAttachment;
+    private final FrameBuffer frameBuffer;
+    private final ShadowsRenderPass shadowsRenderPass;
 
     public ShadowsFrameBuffer(Device device) {
         LOGGER.debug("Creating ShadowsFrameBuffer");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
@@ -12,8 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class ShadowsRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public ShadowsRenderPass(Device device, Attachment depthAttachment) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,9 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
-    private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
+    private final Image image;
+    private final ImageView imageView;
+    private final boolean depthAttachment;
 
     public Attachment(Image image, ImageView imageView, boolean depthAttachment) {
         this.image = image;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ComputePipeline.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ComputePipeline.java
@@ -16,9 +16,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class ComputePipeline {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public ComputePipeline(PipelineCache pipelineCache, ComputePipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating compute pipeline");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,10 +13,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private MemoryAllocator memoryAllocator;
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final MemoryAllocator memoryAllocator;
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(Instance instance, PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass, int layers) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int MAT4X4_SIZE = 16 * FLOAT_LENGTH;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this(device, width, height, format, usage, mipLevels, sampleCount, 1);

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,10 +10,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private int aspectMask;
-    private Device device;
-    private int mipLevels;
-    private long vkImageView;
+    private final int aspectMask;
+    private final Device device;
+    private final int mipLevels;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this(device, vkImage, format, aspectMask, mipLevels, VK_IMAGE_VIEW_TYPE_2D, 0, 1);

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
@@ -10,7 +10,7 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class MemoryAllocator {
 
-    private long vmaAllocator;
+    private final long vmaAllocator;
 
     public MemoryAllocator(Instance instance, PhysicalDevice physicalDevice, VkDevice vkDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/MemoryBarrier.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/MemoryBarrier.java
@@ -6,7 +6,7 @@ import static org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
 
 public class MemoryBarrier {
 
-    private VkMemoryBarrier.Buffer vkMemoryBarrier;
+    private final VkMemoryBarrier.Buffer vkMemoryBarrier;
 
     public MemoryBarrier(int srcAccessMask, int dstAccessMask) {
         vkMemoryBarrier = VkMemoryBarrier.calloc(1)

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -15,12 +15,12 @@ public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private Set<Integer> suportedSampleCount;
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -30,28 +30,28 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             suportedSampleCount = calSupportedSampleCount(vkPhysicalDeviceProperties);
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private String fileName;
-    private boolean hasTransparencies;
-    private int height;
-    private Image image;
-    private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+
+    private final String fileName;
+    private final int height;
+    private final Image image;
+    private final ImageView imageView;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -10,8 +10,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     private static final int NORMAL_COMPONENTS = 3;
     private static final int NUMBER_OF_ATTRIBUTES = 5;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocation;
-    private long buffer;
-    private Device device;
+    private final long allocation;
+    private final long buffer;
+    private final Device device;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int bufferUsage, int memoryUsage,
                         int requiredFlags) {

--- a/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-14/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,9 +13,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+
     private List<VulkanModel.VulkanAnimation> animationList;
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/Window.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/Window.java
@@ -7,7 +7,7 @@ import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
 
-public class Window implements GLFWFramebufferSizeCallbackI {
+public class Window {
 
     private int height;
     private MouseInput mouseInput;
@@ -76,11 +76,6 @@ public class Window implements GLFWFramebufferSizeCallbackI {
 
     public long getWindowHandle() {
         return windowHandle;
-    }
-
-    @Override
-    public void invoke(long handle, int width, int height) {
-        resize(width, height);
     }
 
     public boolean isKeyPressed(int keyCode) {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/Render.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/Render.java
@@ -14,23 +14,26 @@ import org.vulkanb.eng.scene.*;
 import java.util.*;
 
 public class Render {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private AnimationComputeActivity animationComputeActivity;
-    private CommandPool commandPool;
-    private Device device;
-    private GeometryRenderActivity geometryRenderActivity;
-    private Queue.GraphicsQueue graphQueue;
-    private GuiRenderActivity guiRenderActivity;
-    private Instance instance;
-    private LightingRenderActivity lightingRenderActivity;
-    private PhysicalDevice physicalDevice;
-    private PipelineCache pipelineCache;
-    private Queue.PresentQueue presentQueue;
-    private ShadowRenderActivity shadowRenderActivity;
-    private Surface surface;
+
+    private final AnimationComputeActivity animationComputeActivity;
+    private final CommandPool commandPool;
+    private final Device device;
+    private final GeometryRenderActivity geometryRenderActivity;
+    private final Queue.GraphicsQueue graphQueue;
+    private final GuiRenderActivity guiRenderActivity;
+    private final Instance instance;
+    private final LightingRenderActivity lightingRenderActivity;
+    private final PhysicalDevice physicalDevice;
+    private final PipelineCache pipelineCache;
+    private final Queue.PresentQueue presentQueue;
+    private final ShadowRenderActivity shadowRenderActivity;
+    private final Surface surface;
+    private final TextureCache textureCache;
+    private final List<VulkanModel> vulkanModels;
+
     private SwapChain swapChain;
-    private TextureCache textureCache;
-    private List<VulkanModel> vulkanModels;
 
     public Render(Window window, Scene scene) {
         EngineProperties engProps = EngineProperties.getInstance();

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/TextureCache.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/TextureCache.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class TextureCache {
 
-    private Map<String, Texture> textureMap;
+    private final Map<String, Texture> textureMap;
 
     public TextureCache() {
         textureMap = new HashMap<>();

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/animation/AnimationComputeActivity.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/animation/AnimationComputeActivity.java
@@ -18,19 +18,21 @@ public class AnimationComputeActivity {
     private static final String ANIM_COMPUTE_SHADER_FILE_GLSL = "resources/shaders/animations_comp.glsl";
     private static final String ANIM_COMPUTE_SHADER_FILE_SPV = ANIM_COMPUTE_SHADER_FILE_GLSL + ".spv";
     private static final int LOCAL_SIZE_X = 32;
+
+    private final Device device;
+    private final MemoryBarrier memoryBarrier;
+    private final Queue.ComputeQueue computeQueue;
+    // Key is the entity id
+    private final Map<String, List<EntityAnimationBuffer>> entityAnimationsBuffers;
+    // Key is the model id
+    private final Map<String, ModelDescriptorSets> modelDescriptorSetsMap;
+    private final Scene scene;
+
     private CommandBuffer commandBuffer;
     private ComputePipeline computePipeline;
-    private Queue.ComputeQueue computeQueue;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
-    // Key is the entity id
-    private Map<String, List<EntityAnimationBuffer>> entityAnimationsBuffers;
     private Fence fence;
-    private MemoryBarrier memoryBarrier;
-    // Key is the model id
-    private Map<String, ModelDescriptorSets> modelDescriptorSetsMap;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private DescriptorSetLayout.StorageDescriptorSetLayout storageDescriptorSetLayout;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryAttachments.java
@@ -10,10 +10,11 @@ public class GeometryAttachments {
 
     private static final int NUMBER_ATTACHMENTS = 4;
     public static final int NUMBER_COLOR_ATTACHMENTS = NUMBER_ATTACHMENTS - 1;
-    private List<Attachment> attachments;
-    private Attachment deptAttachment;
-    private int height;
-    private int width;
+
+    private final List<Attachment> attachments;
+    private final Attachment deptAttachment;
+    private final int height;
+    private final int width;
 
     public GeometryAttachments(Device device, int width, int height) {
         this.width = width;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryFrameBuffer.java
@@ -12,9 +12,10 @@ public class GeometryFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private final GeometryRenderPass geometryRenderPass;
+
     private FrameBuffer frameBuffer;
     private GeometryAttachments geometryAttachments;
-    private GeometryRenderPass geometryRenderPass;
 
     public GeometryFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating GeometryFrameBuffer");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderActivity.java
@@ -20,23 +20,25 @@ public class GeometryRenderActivity {
     private static final String GEOMETRY_FRAGMENT_SHADER_FILE_SPV = GEOMETRY_FRAGMENT_SHADER_FILE_GLSL + ".spv";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_GLSL = "resources/shaders/geometry_vertex.glsl";
     private static final String GEOMETRY_VERTEX_SHADER_FILE_SPV = GEOMETRY_VERTEX_SHADER_FILE_GLSL + ".spv";
+
+    private final Device device;
+    private final GeometryFrameBuffer geometryFrameBuffer;
+    private final int materialSize;
+    private final MemoryBarrier memoryBarrier;
+    private final PipelineCache pipelineCache;
+    private final Scene scene;
+
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private Map<String, TextureDescriptorSet> descriptorSetMap;
-    private Device device;
     private Fence[] fences;
     private DescriptorSetLayout[] geometryDescriptorSetLayouts;
-    private GeometryFrameBuffer geometryFrameBuffer;
     private DescriptorSetLayout.DynUniformDescriptorSetLayout materialDescriptorSetLayout;
-    private int materialSize;
     private VulkanBuffer materialsBuffer;
     private DescriptorSet.DynUniformDescriptorSet materialsDescriptorSet;
-    private MemoryBarrier memoryBarrier;
     private Pipeline pipeLine;
-    private PipelineCache pipelineCache;
     private DescriptorSet.UniformDescriptorSet projMatrixDescriptorSet;
     private VulkanBuffer projMatrixUniform;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private SwapChain swapChain;
     private DescriptorSetLayout.SamplerDescriptorSetLayout textureDescriptorSetLayout;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/geometry/GeometryRenderPass.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class GeometryRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public GeometryRenderPass(Device device, List<Attachment> attachments) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsDescriptorSet.java
@@ -12,9 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsDescriptorSet extends DescriptorSet {
 
-    private int binding;
-    private Device device;
-    private TextureSampler textureSampler;
+    private final Device device;
+    private final int binding;
+    private final TextureSampler textureSampler;
 
     public AttachmentsDescriptorSet(DescriptorPool descriptorPool, AttachmentsLayout descriptorSetLayout,
                                     List<Attachment> attachments, int binding) {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/AttachmentsLayout.java
@@ -11,6 +11,7 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class AttachmentsLayout extends DescriptorSetLayout {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
     public AttachmentsLayout(Device device, int numAttachments) {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightSpecConstants.java
@@ -9,10 +9,9 @@ import java.nio.ByteBuffer;
 
 public class LightSpecConstants {
 
-    private ByteBuffer data;
-
-    private VkSpecializationMapEntry.Buffer specEntryMap;
-    private VkSpecializationInfo specInfo;
+    private final ByteBuffer data;
+    private final VkSpecializationMapEntry.Buffer specEntryMap;
+    private final VkSpecializationInfo specInfo;
 
     public LightSpecConstants() {
         EngineProperties engineProperties = EngineProperties.getInstance();

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingFrameBuffer.java
@@ -9,9 +9,12 @@ import java.nio.LongBuffer;
 import java.util.Arrays;
 
 public class LightingFrameBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final LightingRenderPass lightingRenderPass;
+
     private FrameBuffer[] frameBuffers;
-    private LightingRenderPass lightingRenderPass;
 
     public LightingFrameBuffer(SwapChain swapChain) {
         LOGGER.debug("Creating Lighting FrameBuffer");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderActivity.java
@@ -22,22 +22,23 @@ public class LightingRenderActivity {
     private static final String LIGHTING_VERTEX_SHADER_FILE_GLSL = "resources/shaders/lighting_vertex.glsl";
     private static final String LIGHTING_VERTEX_SHADER_FILE_SPV = LIGHTING_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Vector4f auxVec;
+    private final LightSpecConstants lightSpecConstants;
+    private final LightingFrameBuffer lightingFrameBuffer;
+    private final Scene scene;
+
     private AttachmentsDescriptorSet attachmentsDescriptorSet;
     private AttachmentsLayout attachmentsLayout;
-    private Vector4f auxVec;
     private CommandBuffer[] commandBuffers;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Fence[] fences;
     private VulkanBuffer[] invMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] invMatricesDescriptorSets;
-    private LightSpecConstants lightSpecConstants;
-    private LightingFrameBuffer lightingFrameBuffer;
     private VulkanBuffer[] lightsBuffers;
     private DescriptorSet.UniformDescriptorSet[] lightsDescriptorSets;
     private Pipeline pipeline;
-    private Scene scene;
     private ShaderProgram shaderProgram;
     private VulkanBuffer[] shadowsMatricesBuffers;
     private DescriptorSet.UniformDescriptorSet[] shadowsMatricesDescriptorSets;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/lighting/LightingRenderPass.java
@@ -11,8 +11,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class LightingRenderPass {
 
-    private Device device;
-    private long vkRenderPass;
+    private final Device device;
+    private final long vkRenderPass;
 
     public LightingRenderPass(SwapChain swapChain) {
         device = swapChain.getDevice();

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowRenderActivity.java
@@ -22,15 +22,16 @@ public class ShadowRenderActivity {
     private static final String SHADOW_VERTEX_SHADER_FILE_GLSL = "resources/shaders/shadow_vertex.glsl";
     private static final String SHADOW_VERTEX_SHADER_FILE_SPV = SHADOW_VERTEX_SHADER_FILE_GLSL + ".spv";
 
+    private final Device device;
+    private final Scene scene;
+    private final ShadowsFrameBuffer shadowsFrameBuffer;
+
     private List<CascadeShadow> cascadeShadows;
     private DescriptorPool descriptorPool;
     private DescriptorSetLayout[] descriptorSetLayouts;
-    private Device device;
     private Pipeline pipeLine;
     private DescriptorSet.UniformDescriptorSet[] projMatrixDescriptorSet;
-    private Scene scene;
     private ShaderProgram shaderProgram;
-    private ShadowsFrameBuffer shadowsFrameBuffer;
     private VulkanBuffer[] shadowsUniforms;
     private SwapChain swapChain;
     private DescriptorSetLayout.UniformDescriptorSetLayout uniformDescriptorSetLayout;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsFrameBuffer.java
@@ -13,9 +13,9 @@ public class ShadowsFrameBuffer {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Attachment depthAttachment;
-    private FrameBuffer frameBuffer;
-    private ShadowsRenderPass shadowsRenderPass;
+    private final Attachment depthAttachment;
+    private final FrameBuffer frameBuffer;
+    private final ShadowsRenderPass shadowsRenderPass;
 
     public ShadowsFrameBuffer(Device device) {
         LOGGER.debug("Creating ShadowsFrameBuffer");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/shadows/ShadowsRenderPass.java
@@ -12,8 +12,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class ShadowsRenderPass {
 
     private static final int MAX_SAMPLES = 1;
-    private Device device;
-    private long vkRenderPass;
+
+    private final Device device;
+    private final long vkRenderPass;
 
     public ShadowsRenderPass(Device device, Attachment depthAttachment) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Attachment.java
@@ -4,9 +4,9 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Attachment {
 
-    private boolean depthAttachment;
-    private Image image;
-    private ImageView imageView;
+    private final Image image;
+    private final ImageView imageView;
+    private final boolean depthAttachment;
 
     public Attachment(Image image, ImageView imageView, boolean depthAttachment) {
         this.image = image;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/CommandBuffer.java
@@ -9,16 +9,18 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandBuffer {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private CommandPool commandPool;
-    private boolean oneTimeSubmit;
-    private VkCommandBuffer vkCommandBuffer;
+
+    private final CommandPool commandPool;
+    private final boolean oneTimeSubmit;
+    private final VkCommandBuffer vkCommandBuffer;
 
     public CommandBuffer(CommandPool commandPool, boolean primary, boolean oneTimeSubmit) {
         LOGGER.trace("Creating command buffer");
         this.commandPool = commandPool;
         this.oneTimeSubmit = oneTimeSubmit;
-        VkDevice vkDevice = this.commandPool.getDevice().getVkDevice();
+        VkDevice vkDevice = commandPool.getDevice().getVkDevice();
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             VkCommandBufferAllocateInfo cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/CommandPool.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class CommandPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkCommandPool;
+
+    private final Device device;
+    private final long vkCommandPool;
 
     public CommandPool(Device device, int queueFamilyIndex) {
         LOGGER.debug("Creating Vulkan CommandPool");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ComputePipeline.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ComputePipeline.java
@@ -15,10 +15,12 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ComputePipeline {
 
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public ComputePipeline(PipelineCache pipelineCache, ComputePipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating compute pipeline");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/DescriptorPool.java
@@ -11,10 +11,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class DescriptorPool {
+
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private long vkDescriptorPool;
+    private final Device device;
+    private final long vkDescriptorPool;
 
     public DescriptorPool(Device device, List<DescriptorTypeCount> descriptorTypeCounts) {
         LOGGER.debug("Creating descriptor pool");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/DescriptorSetLayout.java
@@ -13,9 +13,9 @@ public abstract class DescriptorSetLayout {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    protected long vkDescriptorLayout;
+    private final Device device;
 
-    private Device device;
+    protected long vkDescriptorLayout;
 
     protected DescriptorSetLayout(Device device) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Device.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Device.java
@@ -13,10 +13,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Device {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private MemoryAllocator memoryAllocator;
-    private PhysicalDevice physicalDevice;
-    private boolean samplerAnisotropy;
-    private VkDevice vkDevice;
+
+    private final MemoryAllocator memoryAllocator;
+    private final PhysicalDevice physicalDevice;
+    private final boolean samplerAnisotropy;
+    private final VkDevice vkDevice;
 
     public Device(Instance instance, PhysicalDevice physicalDevice) {
         LOGGER.debug("Creating device");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Fence.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Fence {
 
-    private Device device;
-    private long vkFence;
+    private final Device device;
+    private final long vkFence;
 
     public Fence(Device device, boolean signaled) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/FrameBuffer.java
@@ -9,8 +9,9 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class FrameBuffer {
-    private Device device;
-    private long vkFrameBuffer;
+
+    private final Device device;
+    private final long vkFrameBuffer;
 
     public FrameBuffer(Device device, int width, int height, LongBuffer pAttachments, long renderPass, int layers) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/GraphConstants.java
@@ -1,6 +1,7 @@
 package org.vulkanb.eng.graph.vk;
 
 public final class GraphConstants {
+
     public static final int FLOAT_LENGTH = 4;
     public static final int INT_LENGTH = 4;
     public static final int SHORT_LENGTH = 2;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Image.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Image.java
@@ -10,11 +10,11 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Image {
 
-    private Device device;
-    private int format;
-    private int mipLevels;
-    private long vkImage;
-    private long vkMemory;
+    private final Device device;
+    private final int format;
+    private final int mipLevels;
+    private final long vkImage;
+    private final long vkMemory;
 
     public Image(Device device, int width, int height, int format, int usage, int mipLevels, int sampleCount) {
         this(device, width, height, format, usage, mipLevels, sampleCount, 1);

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ImageView.java
@@ -10,10 +10,10 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class ImageView {
 
-    private int aspectMask;
-    private Device device;
-    private int mipLevels;
-    private long vkImageView;
+    private final int aspectMask;
+    private final Device device;
+    private final int mipLevels;
+    private final long vkImageView;
 
     public ImageView(Device device, long vkImage, int format, int aspectMask, int mipLevels) {
         this(device, vkImage, format, aspectMask, mipLevels, VK_IMAGE_VIEW_TYPE_2D, 0, 1);

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -25,6 +25,7 @@ public class Instance {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final VkInstance vkInstance;
+
     private VkDebugUtilsMessengerCreateInfoEXT debugUtils;
     private long vkDebugHandle;
 

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -8,6 +8,7 @@ import org.lwjgl.vulkan.*;
 
 import java.nio.*;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.lwjgl.vulkan.EXTDebugUtils.*;
 import static org.lwjgl.vulkan.VK11.*;
@@ -41,8 +42,8 @@ public class Instance {
                     .apiVersion(VK_API_VERSION_1_1);
 
             // Validation layers
-            String[] validationLayers = validate ? getSupportedValidationLayers(stack) : null;
-            int numValidationLayers = validationLayers != null ? validationLayers.length : 0;
+            List<String> validationLayers = getSupportedValidationLayers();
+            int numValidationLayers = validationLayers.size();
             boolean supportsValidation = validate;
             if (validate && numValidationLayers == 0) {
                 supportsValidation = false;
@@ -55,8 +56,8 @@ public class Instance {
             if (supportsValidation) {
                 requiredLayers = stack.mallocPointer(numValidationLayers);
                 for (int i = 0; i < numValidationLayers; i++) {
-                    LOGGER.debug("Using validation layer [{}]", validationLayers[i]);
-                    requiredLayers.put(i, stack.ASCII(validationLayers[i]));
+                    LOGGER.debug("Using validation layer [{}]", validationLayers.get(i));
+                    requiredLayers.put(i, stack.ASCII(validationLayers.get(i)));
                 }
             }
 
@@ -139,52 +140,60 @@ public class Instance {
         vkDestroyInstance(vkInstance, null);
     }
 
-    private String[] getSupportedValidationLayers(MemoryStack stack) {
-        Set<String> supportedLayers = new HashSet<>();
-        IntBuffer numLayersArr = stack.callocInt(1);
-        vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr.get(0);
-        LOGGER.debug("Instance supports [{}] layers", numLayers);
+    private List<String> getSupportedValidationLayers() {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer numLayersArr = stack.callocInt(1);
+            vkEnumerateInstanceLayerProperties(numLayersArr, null);
+            int numLayers = numLayersArr.get(0);
+            LOGGER.debug("Instance supports [{}] layers", numLayers);
 
-        VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
-        vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
-        for (int i = 0; i < numLayers; i++) {
-            VkLayerProperties props = propsBuf.get(i);
-            String layerName = props.layerNameString();
-            supportedLayers.add(layerName);
-            LOGGER.debug("Supported layer [{}]", layerName);
-        }
-
-        String[][] validationLayers = new String[][]{
-                // Preferred one
-                {"VK_LAYER_KHRONOS_validation"},
-                // If not available, check LunarG meta layer
-                {"VK_LAYER_LUNARG_standard_validation"},
-                // If not available, check individual layers
-                {
-                        "VK_LAYER_GOOGLE_threading",
-                        "VK_LAYER_LUNARG_parameter_validation",
-                        "VK_LAYER_LUNARG_object_tracker",
-                        "VK_LAYER_LUNARG_core_validation",
-                        "VK_LAYER_GOOGLE_unique_objects",
-                },
-                // Last resort
-                {"VK_LAYER_LUNARG_core_validation"}
-        };
-
-        String[] selectedLayers = null;
-        for (String[] layers : validationLayers) {
-            boolean supported = true;
-            for (String layerName : layers) {
-                supported = supported && supportedLayers.contains(layerName);
+            VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);
+            vkEnumerateInstanceLayerProperties(numLayersArr, propsBuf);
+            List<String> supportedLayers = new ArrayList<>();
+            for (int i = 0; i < numLayers; i++) {
+                VkLayerProperties props = propsBuf.get(i);
+                String layerName = props.layerNameString();
+                supportedLayers.add(layerName);
+                LOGGER.debug("Supported layer [{}]", layerName);
             }
-            if (supported) {
-                selectedLayers = layers;
-                break;
-            }
-        }
 
-        return selectedLayers;
+            List<String> layersToUse = new ArrayList<>();
+
+            // Main validation layer
+            if (supportedLayers.contains("VK_LAYER_KHRONOS_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 1
+            if (supportedLayers.contains("VK_LAYER_LUNARG_standard_validation")) {
+                layersToUse.add("VK_LAYER_KHRONOS_validation");
+                return layersToUse;
+            }
+
+            // Fallback 2 (set)
+            List<String> requestedLayers = new ArrayList<>();
+            requestedLayers.add("VK_LAYER_GOOGLE_threading");
+            requestedLayers.add("VK_LAYER_LUNARG_parameter_validation");
+            requestedLayers.add("VK_LAYER_LUNARG_object_tracker");
+            requestedLayers.add("VK_LAYER_LUNARG_core_validation");
+            requestedLayers.add("VK_LAYER_GOOGLE_unique_objects");
+
+            List<String> overlap = requestedLayers.stream().filter(requestedLayers::contains).collect(Collectors.toList());
+
+            if (overlap.size() > 0) {
+                return overlap;
+            }
+
+            // Fallback 3
+            if (supportedLayers.contains("VK_LAYER_LUNARG_core_validation")) {
+                layersToUse.add("VK_LAYER_LUNARG_core_validation");
+                return layersToUse;
+            }
+
+            // Returns empty list
+            return layersToUse;
+        }
     }
 
     public VkInstance getVkInstance() {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -107,7 +107,7 @@ public class Instance {
     }
 
     private static VkDebugUtilsMessengerCreateInfoEXT createDebugCallBack() {
-        VkDebugUtilsMessengerCreateInfoEXT result = VkDebugUtilsMessengerCreateInfoEXT
+        return VkDebugUtilsMessengerCreateInfoEXT
                 .calloc()
                 .sType(VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT)
                 .messageSeverity(MESSAGE_SEVERITY_BITMASK)
@@ -126,7 +126,6 @@ public class Instance {
                     LOGGER.log(logLevel, "VkDebugUtilsCallback, {}", callbackData.pMessageString());
                     return VK_FALSE;
                 });
-        return result;
     }
 
     public void cleanup() {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Instance.java
@@ -141,9 +141,9 @@ public class Instance {
 
     private String[] getSupportedValidationLayers(MemoryStack stack) {
         Set<String> supportedLayers = new HashSet<>();
-        int[] numLayersArr = new int[1];
+        IntBuffer numLayersArr = stack.callocInt(1);
         vkEnumerateInstanceLayerProperties(numLayersArr, null);
-        int numLayers = numLayersArr[0];
+        int numLayers = numLayersArr.get(0);
         LOGGER.debug("Instance supports [{}] layers", numLayers);
 
         VkLayerProperties.Buffer propsBuf = VkLayerProperties.callocStack(numLayers, stack);

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/MemoryAllocator.java
@@ -10,7 +10,7 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class MemoryAllocator {
 
-    private long vmaAllocator;
+    private final long vmaAllocator;
 
     public MemoryAllocator(Instance instance, PhysicalDevice physicalDevice, VkDevice vkDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/MemoryBarrier.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/MemoryBarrier.java
@@ -6,7 +6,7 @@ import static org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
 
 public class MemoryBarrier {
 
-    private VkMemoryBarrier.Buffer vkMemoryBarrier;
+    private final VkMemoryBarrier.Buffer vkMemoryBarrier;
 
     public MemoryBarrier(int srcAccessMask, int dstAccessMask) {
         vkMemoryBarrier = VkMemoryBarrier.calloc(1)

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/PhysicalDevice.java
@@ -15,12 +15,12 @@ public class PhysicalDevice {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private Set<Integer> suportedSampleCount;
-    private VkExtensionProperties.Buffer vkDeviceExtensions;
-    private VkPhysicalDeviceMemoryProperties vkMemoryProperties;
-    private VkPhysicalDevice vkPhysicalDevice;
-    private VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
-    private VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
-    private VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
+    private final VkExtensionProperties.Buffer vkDeviceExtensions;
+    private final VkPhysicalDeviceMemoryProperties vkMemoryProperties;
+    private final VkPhysicalDevice vkPhysicalDevice;
+    private final VkPhysicalDeviceFeatures vkPhysicalDeviceFeatures;
+    private final VkPhysicalDeviceProperties vkPhysicalDeviceProperties;
+    private final VkQueueFamilyProperties.Buffer vkQueueFamilyProps;
 
     private PhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -30,28 +30,28 @@ public class PhysicalDevice {
 
             // Get device properties
             vkPhysicalDeviceProperties = VkPhysicalDeviceProperties.calloc();
-            vkGetPhysicalDeviceProperties(this.vkPhysicalDevice, vkPhysicalDeviceProperties);
+            vkGetPhysicalDeviceProperties(vkPhysicalDevice, vkPhysicalDeviceProperties);
 
             // Get device extensions
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, null),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, null),
                     "Failed to get number of device extension properties");
             vkDeviceExtensions = VkExtensionProperties.calloc(intBuffer.get(0));
-            vkCheck(vkEnumerateDeviceExtensionProperties(this.vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
+            vkCheck(vkEnumerateDeviceExtensionProperties(vkPhysicalDevice, (String) null, intBuffer, vkDeviceExtensions),
                     "Failed to get extension properties");
 
             suportedSampleCount = calSupportedSampleCount(vkPhysicalDeviceProperties);
 
             // Get Queue family properties
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, null);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, null);
             vkQueueFamilyProps = VkQueueFamilyProperties.calloc(intBuffer.get(0));
-            vkGetPhysicalDeviceQueueFamilyProperties(this.vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
+            vkGetPhysicalDeviceQueueFamilyProperties(vkPhysicalDevice, intBuffer, vkQueueFamilyProps);
 
             vkPhysicalDeviceFeatures = VkPhysicalDeviceFeatures.calloc();
-            vkGetPhysicalDeviceFeatures(this.vkPhysicalDevice, vkPhysicalDeviceFeatures);
+            vkGetPhysicalDeviceFeatures(vkPhysicalDevice, vkPhysicalDeviceFeatures);
 
             // Get Memory information and properties
             vkMemoryProperties = VkPhysicalDeviceMemoryProperties.calloc();
-            vkGetPhysicalDeviceMemoryProperties(this.vkPhysicalDevice, vkMemoryProperties);
+            vkGetPhysicalDeviceMemoryProperties(vkPhysicalDevice, vkMemoryProperties);
         }
     }
 

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Pipeline.java
@@ -10,10 +10,12 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Pipeline {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipeline;
-    private long vkPipelineLayout;
+
+    private final Device device;
+    private final long vkPipeline;
+    private final long vkPipelineLayout;
 
     public Pipeline(PipelineCache pipelineCache, Pipeline.PipeLineCreationInfo pipeLineCreationInfo) {
         LOGGER.debug("Creating pipeline");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/PipelineCache.java
@@ -10,9 +10,11 @@ import static org.lwjgl.vulkan.VK11.*;
 import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class PipelineCache {
+
     private static final Logger LOGGER = LogManager.getLogger();
-    private Device device;
-    private long vkPipelineCache;
+
+    private final Device device;
+    private final long vkPipelineCache;
 
     public PipelineCache(Device device) {
         LOGGER.debug("Creating pipeline cache");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Queue.java
@@ -13,8 +13,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class Queue {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int queueFamilyIndex;
-    private VkQueue vkQueue;
+
+    private final int queueFamilyIndex;
+    private final VkQueue vkQueue;
 
     public Queue(Device device, int queueFamilyIndex, int queueIndex) {
         LOGGER.debug("Creating queue");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Semaphore.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class Semaphore {
 
-    private Device device;
-    private long vkSemaphore;
+    private final Device device;
+    private final long vkSemaphore;
 
     public Semaphore(Device device) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/ShaderProgram.java
@@ -15,8 +15,8 @@ public class ShaderProgram {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private Device device;
-    private ShaderModule[] shaderModules;
+    private final Device device;
+    private final ShaderModule[] shaderModules;
 
     public ShaderProgram(Device device, ShaderModuleData[] shaderModuleData) {
         try {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Surface.java
@@ -10,8 +10,9 @@ import java.nio.LongBuffer;
 public class Surface {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private PhysicalDevice physicalDevice;
-    private long vkSurface;
+
+    private final PhysicalDevice physicalDevice;
+    private final long vkSurface;
 
     public Surface(PhysicalDevice physicalDevice, long windowHandle) {
         LOGGER.debug("Creating Vulkan surface");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/SwapChain.java
@@ -14,13 +14,15 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class SwapChain {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Device device;
+    private final ImageView[] imageViews;
+    private final SurfaceFormat surfaceFormat;
+    private final VkExtent2D swapChainExtent;
+    private final SyncSemaphores[] syncSemaphoresList;
+    private final long vkSwapChain;
+
     private int currentFrame;
-    private Device device;
-    private ImageView[] imageViews;
-    private SurfaceFormat surfaceFormat;
-    private VkExtent2D swapChainExtent;
-    private SyncSemaphores[] syncSemaphoresList;
-    private long vkSwapChain;
 
     public SwapChain(Device device, Surface surface, Window window, int requestedImages, boolean vsync) {
         LOGGER.debug("Creating Vulkan SwapChain");

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/SwapChainRenderPass.java
@@ -10,8 +10,8 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class SwapChainRenderPass {
 
-    private SwapChain swapChain;
-    private long vkRenderPass;
+    private final SwapChain swapChain;
+    private final long vkRenderPass;
 
     public SwapChainRenderPass(SwapChain swapChain, int depthImageFormat) {
         this.swapChain = swapChain;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/Texture.java
@@ -11,18 +11,20 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class Texture {
 
+    private static final Logger LOGGER = LogManager.getLogger();
     // RGBA
     private static final int BYTES_PER_PIXEL = 4;
-    private static final Logger LOGGER = LogManager.getLogger();
+
     private String fileName;
-    private boolean hasTransparencies;
-    private int height;
+    private final int height;
     private Image image;
     private ImageView imageView;
-    private int mipLevels;
-    private boolean recordedTransition;
+    private final int mipLevels;
+    private final int width;
+
     private VulkanBuffer stgBuffer;
-    private int width;
+    private boolean recordedTransition;
+    private boolean hasTransparencies;
 
     public Texture(Device device, String fileName, int imageFormat) {
         LOGGER.debug("Creating texture [{}]", fileName);

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/TextureSampler.java
@@ -11,8 +11,9 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 public class TextureSampler {
 
     private static final int MAX_ANISOTROPY = 16;
-    private Device device;
-    private long vkSampler;
+
+    private final Device device;
+    private final long vkSampler;
 
     public TextureSampler(Device device, int mipLevels) {
         this.device = device;

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VertexBufferStructure.java
@@ -10,8 +10,9 @@ public class VertexBufferStructure extends VertexInputStateInfo {
     private static final int NORMAL_COMPONENTS = 3;
     private static final int NUMBER_OF_ATTRIBUTES = 5;
     private static final int POSITION_COMPONENTS = 3;
-    private VkVertexInputAttributeDescription.Buffer viAttrs;
-    private VkVertexInputBindingDescription.Buffer viBindings;
+
+    private final VkVertexInputAttributeDescription.Buffer viAttrs;
+    private final VkVertexInputBindingDescription.Buffer viBindings;
 
     public VertexBufferStructure() {
         viAttrs = VkVertexInputAttributeDescription.calloc(NUMBER_OF_ATTRIBUTES);

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VulkanBuffer.java
@@ -14,12 +14,13 @@ import static org.vulkanb.eng.graph.vk.VulkanUtils.vkCheck;
 
 public class VulkanBuffer {
 
-    private long allocation;
-    private long buffer;
-    private Device device;
+    private final long allocation;
+    private final long buffer;
+    private final Device device;
+    private final PointerBuffer pb;
+    private final long requestedSize;
+
     private long mappedMemory;
-    private PointerBuffer pb;
-    private long requestedSize;
 
     public VulkanBuffer(Device device, long size, int bufferUsage, int memoryUsage,
                         int requiredFlags) {

--- a/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
+++ b/booksamples/chapter-15/src/main/java/org/vulkanb/eng/graph/vk/VulkanModel.java
@@ -13,9 +13,10 @@ import static org.lwjgl.vulkan.VK11.*;
 
 public class VulkanModel {
 
+    private final String modelId;
+    private final List<VulkanModel.VulkanMaterial> vulkanMaterialList;
+
     private List<VulkanModel.VulkanAnimation> animationList;
-    private String modelId;
-    private List<VulkanModel.VulkanMaterial> vulkanMaterialList;
 
     public VulkanModel(String modelId) {
         this.modelId = modelId;


### PR DESCRIPTION
I've made some changes that I hope you have no objections to. Here's a list of those changes:

* `Instance.java` no longer calls `vkEnumerateInstanceLayerProperties()` with an integer array, instead now with an `IntBuffer`.
* Window class doesn't need to implement GLFWFramebufferSizeCallbackI, since the `invoke()` method would never have been called anyway.
* Reworked getting instance layer names to something a little more readable. Rather than using arrays of arrays, check if the layer is present, and return that.
* Sorted fields in a consistent manner (static final, then final, then mutable). IDEA shouldn't interfere with them.
* Inlined the return of `createDebugCallBack()`.

Lmk what you think.